### PR TITLE
ai/integration: Claude Code 持续集成主 PR

### DIFF
--- a/doc/notes/TODO.md
+++ b/doc/notes/TODO.md
@@ -23,8 +23,8 @@
 
 目标：清理模板残留，让当前工程具备可信的开发基线。
 
-- [ ] P0 清理模板失败测试：修改 `test/lan_clip/core_test.clj`，删除固定失败断言。
-- [ ] P0 运行 `lein test`，确保基础测试通过。
+- [x] P0 清理模板失败测试：修改 `test/lan_clip/core_test.clj`，删除固定失败断言。
+- [x] P0 运行 `lein test`，确保基础测试通过。
 - [ ] P0 更新 `project.clj` 中的 `:description` 和 `:url`。
 - [ ] P1 清理 `CHANGELOG.md` 模板内容，改为 lan-clip 真实变更骨架。
 - [ ] P1 改写 `doc/intro.md`，作为文档入口并链接到 `doc/notes`。
@@ -217,7 +217,7 @@
 
 先从这 10 项开始：
 
-1. [ ] 清理模板测试，使 `lein test` 通过。
+1. [x] 清理模板测试，使 `lein test` 通过。
 2. [ ] 新建 `lan-clip.config`，集中默认配置、读取、校验。
 3. [ ] 新建 `lan-clip.fingerprint`，迁移 `ClipboardData` 和 MD5 判断。
 4. [ ] 抽象 `lan-clip.clipboard`，封装读取/写入文本、图片、文件列表。

--- a/test/lan_clip/core_test.clj
+++ b/test/lan_clip/core_test.clj
@@ -2,6 +2,6 @@
   (:require [clojure.test :refer :all]
             [lan-clip.core :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(deftest core-namespace-loads
+  (testing "lan-clip.core 命名空间应可成功加载"
+    (is (some? (find-ns 'lan-clip.core)))))


### PR DESCRIPTION
## 用途

这是 Claude Code 自主推进任务的总 PR，按 `.claude/loop.md` 与 `.claude/agent-policy.md` 的策略：

- 每轮任务在 `feature/...` 分支完成，先合入 `ai/integration`
- 本 PR 汇总 `ai/integration` 上累计的所有变更
- 由人工审核后再合并到 `master`

## 当前累计内容

- Phase 0 P0：清理 `core_test.clj` 中 lein 模板默认的 `(is (= 0 1))` 失败断言，替换为命名空间加载冒烟测试，使 `lein test` 通过；同步勾选 `doc/notes/TODO.md` 两项 Phase 0 P0。

## 验证

- 在 worktree 中执行 `lein test`：`Ran 1 tests containing 1 assertions. 0 failures, 0 errors.`

## 测试计划

- [ ] 人工 review 本批变更
- [ ] 后续轮次会继续把新的 `feature/*` 合入 `ai/integration` 并在此 PR 累积

🤖 Generated with [Claude Code](https://claude.com/claude-code)