### PR TITLE
ai/integration: Claude Code 持续集成 (第 2 批)

### DIFF
--- a/doc/notes/TODO.md
+++ b/doc/notes/TODO.md
@@ -25,7 +25,7 @@
 
 - [x] P0 清理模板失败测试：修改 `test/lan_clip/core_test.clj`，删除固定失败断言。
 - [x] P0 运行 `lein test`，确保基础测试通过。
-- [ ] P0 更新 `project.clj` 中的 `:description` 和 `:url`。
+- [x] P0 更新 `project.clj` 中的 `:description` 和 `:url`。
 - [ ] P1 清理 `CHANGELOG.md` 模板内容，改为 lan-clip 真实变更骨架。
 - [ ] P1 改写 `doc/intro.md`，作为文档入口并链接到 `doc/notes`。
 - [ ] P1 梳理 `.gitignore`，确认忽略 `.DS_Store`、IDE、本地缓存、构建产物。

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject lan-clip "1.0"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+  :description "lan-clip: 局域网剪贴板同步工具，在同一局域网内的多台设备间互传文本、图片、文件。"
+  :url "https://github.com/lhing17/lan-clip"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]


### PR DESCRIPTION
## 用途

承接已合并的 PR #4，继续作为 Claude Code 自主推进任务的总 PR。每轮任务在 `feature/...` 分支完成后先合入 `ai/integration`，累积到本 PR 等待人工审核与最终合并。

## 本批累计内容

- Phase 0 P0：将 `project.clj` 中 `:description` / `:url` 由 lein 模板占位符（`FIXME: write description` / `http://example.com/FIXME`）改为 lan-clip 真实定位与仓库地址。
- 同步勾选 `doc/notes/TODO.md` 中 Phase 0 P0 第三项。

## 验证

- 在 worktree 中执行 `lein test`：`Ran 1 tests containing 1 assertions. 0 failures, 0 errors.`

## 测试计划

- [ ] 人工 review 元信息文案
- [ ] 后续轮次会继续把新的 `feature/*` 合入 `ai/integration` 并在此 PR 累积

🤖 Generated with [Claude Code](https://claude.com/claude-code)